### PR TITLE
fix(core): Isolate module and function execution scopes

### DIFF
--- a/Packages/com.nueruyu.descrio/Runtime/Execution/ExecutionContext.cs
+++ b/Packages/com.nueruyu.descrio/Runtime/Execution/ExecutionContext.cs
@@ -26,6 +26,11 @@ namespace Descrio.Execution
 
         public ExecutionContext CreateChildContext()
         {
+            return CreateChildContext(CancellationToken);
+        }
+
+        public ExecutionContext CreateChildContext(CancellationToken cancellationToken)
+        {
             var childVariableRegistry = new VariableRegistry(Variables);
             var childCallableRegistry = new CallableRegistry(Callables);
             var childClassRegistry = new ClassRegistry(Classes);
@@ -35,12 +40,7 @@ namespace Descrio.Execution
                 childCallableRegistry,
                 childVariableRegistry,
                 childClassRegistry,
-                CancellationToken);
-        }
-
-        public ExecutionContext CreateForNewPath(ModulePath newPath)
-        {
-            return new ExecutionContext(newPath, Callables, Variables, Classes, CancellationToken);
+                cancellationToken);
         }
     }
 }

--- a/Packages/com.nueruyu.descrio/Runtime/Execution/Interpreter.cs
+++ b/Packages/com.nueruyu.descrio/Runtime/Execution/Interpreter.cs
@@ -169,7 +169,7 @@ namespace Descrio.Execution
         {
             async ValueTask<object> CallAsync(Arguments args, ExecutionContext context)
             {
-                var localContext = context.CreateChildContext();
+                var localContext = _context.CreateChildContext(context.CancellationToken);
 
                 foreach (var param in statement.Parameters)
                 {

--- a/Packages/com.nueruyu.descrio/Runtime/Parse/IModuleLoader.cs
+++ b/Packages/com.nueruyu.descrio/Runtime/Parse/IModuleLoader.cs
@@ -1,0 +1,19 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Descrio.Parse
+{
+    /// <summary>
+    /// Represents a component responsible for loading and parsing a module from a given path.
+    /// </summary>
+    public interface IModuleLoader
+    {
+        /// <summary>
+        /// Asynchronously loads and parses a module from the specified path.
+        /// </summary>
+        /// <param name="path">The path to the module.</param>
+        /// <param name="cancellationToken">A token to observe for cancellation requests.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the loaded and parsed <see cref="Module"/>.</returns>
+        Task<Module> LoadAsync(ModulePath path, CancellationToken cancellationToken);
+    }
+}

--- a/Packages/com.nueruyu.descrio/Runtime/Parse/IModuleLoader.cs.meta
+++ b/Packages/com.nueruyu.descrio/Runtime/Parse/IModuleLoader.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 11f099123a3a79640a4b0d3dc1bae065

--- a/Packages/com.nueruyu.descrio/Runtime/Parse/ModuleLoaders.meta
+++ b/Packages/com.nueruyu.descrio/Runtime/Parse/ModuleLoaders.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b8a32087de3c2024aaf0cf0f6176a7c1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.nueruyu.descrio/Runtime/Parse/ModuleLoaders/InMemoryModuleLoader.cs
+++ b/Packages/com.nueruyu.descrio/Runtime/Parse/ModuleLoaders/InMemoryModuleLoader.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Descrio.Parse.ModuleLoaders
+{
+    public class InMemoryModuleLoader : IModuleLoader
+    {
+        private readonly Dictionary<ModulePath, Module> _modules = new();
+
+        public InMemoryModuleLoader(Dictionary<string, Module> modules)
+        {
+            foreach (var kvp in modules)
+            {
+                _modules.Add(new ModulePath(kvp.Key), kvp.Value);
+            }
+        }
+
+        public Task<Module> LoadAsync(ModulePath path, CancellationToken cancellationToken)
+        {
+            if (_modules.TryGetValue(path, out var module))
+            {
+                return Task.FromResult(module);
+            }
+
+            throw new FileNotFoundException($"Module with path '{path}' not found in memory.", path.ToString());
+        }
+    }
+}

--- a/Packages/com.nueruyu.descrio/Runtime/Parse/ModuleLoaders/InMemoryModuleLoader.cs.meta
+++ b/Packages/com.nueruyu.descrio/Runtime/Parse/ModuleLoaders/InMemoryModuleLoader.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b853bf3add69d9d47876d520fbcebc83

--- a/Packages/com.nueruyu.descrio/Runtime/Parse/ModuleLoaders/StringModuleLoader.cs
+++ b/Packages/com.nueruyu.descrio/Runtime/Parse/ModuleLoaders/StringModuleLoader.cs
@@ -1,0 +1,26 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Descrio.Parse.ModuleLoaders
+{
+    /// <summary>
+    /// Loads module content as a string from a provider and parses it using a script parser.
+    /// </summary>
+    public class StringModuleLoader : IModuleLoader
+    {
+        private readonly IModuleProvider _provider;
+        private readonly IScriptParser _parser;
+
+        public StringModuleLoader(IModuleProvider provider, IScriptParser parser)
+        {
+            _provider = provider;
+            _parser = parser;
+        }
+
+        public async Task<Module> LoadAsync(ModulePath path, CancellationToken cancellationToken)
+        {
+            var scriptText = await _provider.ReadContentAsync(path, cancellationToken);
+            return _parser.Parse(scriptText);
+        }
+    }
+}

--- a/Packages/com.nueruyu.descrio/Runtime/Parse/ModuleLoaders/StringModuleLoader.cs.meta
+++ b/Packages/com.nueruyu.descrio/Runtime/Parse/ModuleLoaders/StringModuleLoader.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e69a60389c6c48e4cac4648565874d30

--- a/Packages/com.nueruyu.descrio/Runtime/ScriptRunner.cs
+++ b/Packages/com.nueruyu.descrio/Runtime/ScriptRunner.cs
@@ -12,15 +12,13 @@ namespace Descrio
 {
     public class ScriptRunner
     {
-        private readonly IScriptParser _parser;
-        private readonly IModuleProvider _moduleProvider;
+        private readonly IModuleLoader _moduleLoader;
         private readonly Dictionary<string, ICallable> _callables = new();
         private readonly Dictionary<string, Type> _types = new();
 
-        public ScriptRunner(IScriptParser parser, IModuleProvider moduleProvider)
+        public ScriptRunner(IModuleLoader moduleLoader)
         {
-            _parser = parser;
-            _moduleProvider = moduleProvider;
+            _moduleLoader = moduleLoader;
         }
 
         /// <summary>
@@ -110,8 +108,7 @@ namespace Descrio
                 return existingModule;
             }
 
-            var scriptText = await _moduleProvider.ReadContentAsync(path, globalContext.CancellationToken);
-            var module = _parser.Parse(scriptText);
+            var module = await _moduleLoader.LoadAsync(path, globalContext.CancellationToken);
 
             loadedModules.RegisterModule(path, module);
 

--- a/Packages/com.nueruyu.descrio/Runtime/ScriptRunner.cs
+++ b/Packages/com.nueruyu.descrio/Runtime/ScriptRunner.cs
@@ -88,42 +88,53 @@ namespace Descrio
             globalClasses.Register("FileNotFoundError", typeof(FileNotFoundException));
 
             var entrypointModulePath = cwdPath.Resolve(entrypointPath);
-            var context = new ExecutionContext(
+            var globalContext = new ExecutionContext(
                 entrypointModulePath.GetDirectoryPath(),
                 globalCallables,
                 globalVariables,
                 globalClasses,
                 cancellationToken);
 
-            await LoadModuleAndDependenciesAsync(entrypointModulePath, context, loadedModules);
+            await LoadModuleAndDependenciesAsync(entrypointModulePath, globalContext, loadedModules);
         }
 
         private async Task<Module> LoadModuleAndDependenciesAsync(
             ModulePath path,
-            ExecutionContext parentContext,
+            ExecutionContext globalContext,
             ModuleRegistry loadedModules)
         {
-            parentContext.CancellationToken.ThrowIfCancellationRequested();
+            globalContext.CancellationToken.ThrowIfCancellationRequested();
 
             if (loadedModules.TryGetModule(path, out var existingModule))
             {
                 return existingModule;
             }
 
-            var scriptText = await _moduleProvider.ReadContentAsync(path, parentContext.CancellationToken);
+            var scriptText = await _moduleProvider.ReadContentAsync(path, globalContext.CancellationToken);
             var module = _parser.Parse(scriptText);
 
             loadedModules.RegisterModule(path, module);
 
-            var moduleContext = parentContext.CreateForNewPath(path.GetDirectoryPath());
+            // Create a context for the current module. It needs the correct directory path
+            // to resolve its own dependencies.
+            var moduleExecutionContext = new ExecutionContext(
+                path.GetDirectoryPath(),
+                globalContext.Callables,
+                new VariableRegistry(globalContext.Variables), // Create a new, isolated variable registry for this module.
+                globalContext.Classes,
+                globalContext.CancellationToken);
 
+            // When loading dependencies, we resolve their paths relative to the CURRENT module,
+            // but we pass the GLOBAL context down to the recursive call. This ensures
+            // that all modules are peers under the global scope, rather than being nested.
             foreach (var importPath in module.ImportPaths)
             {
-                var absoluteImportPath = moduleContext.CurrentDirectory.Resolve(importPath);
-                await LoadModuleAndDependenciesAsync(absoluteImportPath, moduleContext, loadedModules);
+                var absoluteImportPath = moduleExecutionContext.CurrentDirectory.Resolve(importPath);
+                await LoadModuleAndDependenciesAsync(absoluteImportPath, globalContext, loadedModules);
             }
 
-            var interpreter = new Interpreter(moduleContext);
+            // Execute this module's statements using its own isolated context.
+            var interpreter = new Interpreter(moduleExecutionContext);
             await interpreter.ExecuteAsync(module);
 
             return module;

--- a/Packages/com.nueruyu.descrio/Samples~/NpcTalk/Scripts/NpcTalkSample.cs
+++ b/Packages/com.nueruyu.descrio/Samples~/NpcTalk/Scripts/NpcTalkSample.cs
@@ -7,6 +7,7 @@ using Descrio;
 using Descrio.Yaml;
 using System.Collections;
 using Descrio.Parse.ModuleProviders;
+using Descrio.Parse.ModuleLoaders;
 
 namespace Descrio.Samples.NpcTalk
 {
@@ -74,9 +75,10 @@ namespace Descrio.Samples.NpcTalk
             var modules = new Dictionary<string, string> { { "/main.yaml", scriptText } };
             var moduleProvider = new InMemoryModuleProvider(modules);
             var parser = new YamlScriptParser();
+            var moduleLoader = new StringModuleLoader(moduleProvider, parser);
 
             // Register callables from this class instance using the new attribute-based system.
-            var runner = new ScriptRunner(parser, moduleProvider)
+            var runner = new ScriptRunner(moduleLoader)
                 .AddCallables(this);
 
             try

--- a/Packages/com.nueruyu.descrio/Tests/Editor/ScriptRunnerTests.cs
+++ b/Packages/com.nueruyu.descrio/Tests/Editor/ScriptRunnerTests.cs
@@ -1,0 +1,156 @@
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System;
+using System.Linq;
+using static Descrio.EditorTests.TestStatementFactory;
+using static Descrio.EditorTests.TestExpressionFactory;
+using Descrio.Parse.ModuleLoaders;
+using Descrio.Execution;
+
+namespace Descrio.EditorTests
+{
+    [TestFixture]
+    public class ScriptRunnerTests
+    {
+        private List<object> _logHistory;
+        private ICallable _logCallable;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _logHistory = new List<object>();
+            _logCallable = new DelegateCallable((Arguments args, ExecutionContext context) =>
+            {
+                _logHistory.Add(args.FirstOrDefault().Value);
+                return new ValueTask<object>((object)null);
+            });
+        }
+
+        [Test]
+        public void ExecuteAsync_ModuleScopeIsIsolated_VariableFromAnotherModuleIsNotAccessible()
+        {
+            // Arrange
+            var modules = new Dictionary<string, Module>
+            {
+                { "/moduleA.yaml", new Module(
+                    statements: new IStatement[] { Var("x", Literal(10)) },
+                    importPaths: Array.Empty<string>())
+                },
+                { "/main.yaml", new Module(
+                    statements: new IStatement[] { Run("log", ("val", Variable("x"))).Build() },
+                    importPaths: new[] { "/moduleA.yaml" })
+                }
+            };
+            var loader = new InMemoryModuleLoader(modules);
+            var runner = new ScriptRunner(loader).AddCallable("log", _logCallable);
+
+            // Act & Assert
+            var ex = Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await runner.ExecuteAsync("/main.yaml", "/")
+            );
+            StringAssert.Contains("Variable 'x' is not defined", ex.Message);
+        }
+
+        [Test]
+        public async Task ExecuteAsync_ModuleScopesAreIsolated_SameVariableNameDoesNotConflict()
+        {
+            // Arrange
+            var modules = new Dictionary<string, Module>
+            {
+                { "/moduleA.yaml", new Module(
+                    statements: new IStatement[]
+                    {
+                        Var("x", Literal(100)),
+                        Function("get_x_from_a").Body(Return(Variable("x"))).Build()
+                    },
+                    importPaths: Array.Empty<string>())
+                },
+                { "/main.yaml", new Module(
+                    statements: new IStatement[]
+                    {
+                        Var("x", Literal(200)),
+                        Let("x_from_a", Run("get_x_from_a").Build()),
+                        Run("log", ("val", Variable("x_from_a"))).Build(),
+                        Run("log", ("val", Variable("x"))).Build()
+                    },
+                    importPaths: new[] { "/moduleA.yaml" })
+                }
+            };
+            var loader = new InMemoryModuleLoader(modules);
+            var runner = new ScriptRunner(loader).AddCallable("log", _logCallable);
+
+            // Act
+            await runner.ExecuteAsync("/main.yaml", "/");
+
+            // Assert
+            CollectionAssert.AreEqual(new object[] { 100L, 200L }, _logHistory);
+        }
+
+        [Test]
+        public void ExecuteAsync_FunctionHasStaticScope_CannotAccessCallerScopeVariables()
+        {
+            // Arrange
+            var modules = new Dictionary<string, Module>
+            {
+                { "/moduleB.yaml", new Module(
+                    statements: new IStatement[]
+                    {
+                        Function("get_y").Body(Return(Variable("y"))).Build()
+                    },
+                    importPaths: Array.Empty<string>())
+                },
+                { "/main.yaml", new Module(
+                    statements: new IStatement[]
+                    {
+                        Var("y", Literal("value_from_main")),
+                        Run("get_y").Build()
+                    },
+                    importPaths: new[] { "/moduleB.yaml" })
+                }
+            };
+            var loader = new InMemoryModuleLoader(modules);
+            var runner = new ScriptRunner(loader).AddCallable("log", _logCallable);
+
+            // Act & Assert
+            var ex = Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await runner.ExecuteAsync("/main.yaml", "/")
+            );
+            StringAssert.Contains("Variable 'y' is not defined", ex.Message);
+        }
+
+        [Test]
+        public async Task ExecuteAsync_FunctionHasStaticScope_CorrectlyCapturesItsOwnModuleScope()
+        {
+            // Arrange
+            var modules = new Dictionary<string, Module>
+            {
+                { "/moduleB.yaml", new Module(
+                    statements: new IStatement[]
+                    {
+                        Var("y", Literal("value_from_b")),
+                        Function("get_y").Body(Return(Variable("y"))).Build()
+                    },
+                    importPaths: Array.Empty<string>())
+                },
+                { "/main.yaml", new Module(
+                    statements: new IStatement[]
+                    {
+                        Var("y", Literal("value_from_main")),
+                        Let("y_from_b", Run("get_y").Build()),
+                        Run("log", ("val", Variable("y_from_b"))).Build()
+                    },
+                    importPaths: new[] { "/moduleB.yaml" })
+                }
+            };
+            var loader = new InMemoryModuleLoader(modules);
+            var runner = new ScriptRunner(loader).AddCallable("log", _logCallable);
+
+            // Act
+            await runner.ExecuteAsync("/main.yaml", "/");
+
+            // Assert
+            CollectionAssert.AreEqual(new object[] { "value_from_b" }, _logHistory);
+        }
+    }
+}

--- a/Packages/com.nueruyu.descrio/Tests/Editor/ScriptRunnerTests.cs.meta
+++ b/Packages/com.nueruyu.descrio/Tests/Editor/ScriptRunnerTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2c8bf59be75bce34fb327d5179fa83bb


### PR DESCRIPTION
This PR resolves a critical architectural issue where modules and functions did not have properly isolated scopes, leading to unpredictable behavior and potential bugs. It introduces robust scope-handling rules and refactors the module loading process to improve testability.

#### The Problem

1.  **Shared Module Scope:** All loaded modules operated on the same global `VariableRegistry`. This meant variables defined in one module could be accessed and overwritten by another, causing unintended side effects.
2.  **Dynamic Function Scope:** Functions executed within the caller's scope (dynamic scope) rather than the scope in which they were defined (static/lexical scope). This made a function's behavior dependent on where it was called from, breaking encapsulation.

#### Changes

This PR is composed of two main changes:

**1. Scope Isolation and Correction**

-   The `ScriptRunner` now creates a new, dedicated `VariableRegistry` for each module it loads. This registry is parented to the global scope, ensuring modules are isolated from each other but can still access global definitions.
-   The `Interpreter` has been updated to enforce **static (lexical) scoping**. Functions now capture the context of where they are defined and use it to create their execution scope when called.
-   The `CancellationToken` is now correctly propagated from the call site, ensuring that async operations within functions can be cancelled by the caller.

**2. Decoupling the Module Loader**

-   To improve the architecture and enable better testing, a new **`IModuleLoader`** interface has been introduced.
-   The `ScriptRunner` now depends on this interface, decoupling it from the specific data format of the modules (e.g., YAML).
-   A `StringModuleLoader` is provided for production use, and a new `InMemoryModuleLoader` is used for testing.

#### Testing

-   A new test suite, **`ScriptRunnerTests.cs`**, has been added to verify the new scoping rules.
-   Using the `InMemoryModuleLoader`, the tests are completely independent of YAML strings and focus purely on the runtime logic.
-   The tests cover critical scenarios, including:
    -   Variables defined in one module are not accessible in another.
    -   Functions correctly capture variables from their definition scope.
    -   Functions cannot access variables from their caller's scope.

This PR significantly improves the robustness, predictability, and maintainability of the script execution runtime.


Fixes #29