### PR TITLE
feat(core): Implement !lambda for anonymous functions and closures

### DIFF
--- a/Packages/com.nueruyu.descrio/Runtime/Execution/Interpreter.cs
+++ b/Packages/com.nueruyu.descrio/Runtime/Execution/Interpreter.cs
@@ -68,6 +68,7 @@ namespace Descrio.Execution
                 ListExpression e => ExecuteAsync(e),
                 DictionaryExpression e => ExecuteAsync(e),
                 MemberAccessExpression e => ExecuteAsync(e),
+                LambdaExpression e => ExecuteAsync(e),
                 DispatchStatement e => ExecuteAsync(e),
                 RunStatement e => ExecuteAsync(e),
                 _ => throw new NotImplementedException($"Execution for {expression.GetType().Name} is not implemented.")
@@ -150,7 +151,23 @@ namespace Descrio.Execution
         private async ValueTask<VisitResult> ExecuteAsync(RunStatement statement)
         {
             if (!_context.Callables.TryGet(statement.Name, out var callable))
-                throw new InvalidOperationException($"Callable '{statement.Name}' not found.");
+            {
+                if (_context.Variables.TryGet(statement.Name, out var variableValue))
+                {
+                    if (variableValue is ICallable variableAsCallable)
+                    {
+                        callable = variableAsCallable;
+                    }
+                    else
+                    {
+                        throw new InvalidOperationException($"Variable '{statement.Name}' is not a callable function.");
+                    }
+                }
+                else
+                {
+                    throw new InvalidOperationException($"Callable '{statement.Name}' not found.");
+                }
+            }
 
             var args = new Arguments();
             foreach (var (key, valueExpr) in statement.ArgExpressions)
@@ -167,15 +184,39 @@ namespace Descrio.Execution
 
         private ValueTask<VisitResult> ExecuteAsync(FunctionStatement statement)
         {
-            async ValueTask<object> CallAsync(Arguments args, ExecutionContext context)
-            {
-                var localContext = _context.CreateChildContext(context.CancellationToken);
+            var callable = CreateCallable(statement.Parameters, statement.Statements, _context);
+            _context.Callables.Register(statement.Name, callable);
+            return new ValueTask<VisitResult>(VisitResult.Normal);
+        }
 
-                foreach (var param in statement.Parameters)
+        private ValueTask<VisitResult> ExecuteAsync(LambdaExpression expression)
+        {
+            var callable = CreateCallable(expression.Parameters, expression.Statements, _context);
+            return new ValueTask<VisitResult>(VisitResult.NormalWithValue(callable));
+        }
+
+        /// <summary>
+        /// Creates a callable delegate that encapsulates the logic for executing a function's body.
+        /// This method is shared by both named functions and lambda expressions.
+        /// </summary>
+        /// <param name="parameters">The list of parameter definitions for the function.</param>
+        /// <param name="statements">The array of statements that form the function's body.</param>
+        /// <param name="closureContext">The execution context at the point of definition, which will be captured to form a closure.</param>
+        /// <returns>An ICallable instance ready to be executed.</returns>
+        private ICallable CreateCallable(
+            ParameterDefinition[] parameters,
+            IStatement[] statements,
+            ExecutionContext closureContext)
+        {
+            async ValueTask<object> CallAsync(Arguments args, ExecutionContext callSiteContext)
+            {
+                var localContext = closureContext.CreateChildContext(callSiteContext.CancellationToken);
+
+                foreach (var param in parameters)
                 {
                     if (args.TryGetValue(param.Name, out var value))
                     {
-                        localContext.Variables.Define(param.Name, value, isMutable: true); // Function params are mutable
+                        localContext.Variables.Define(param.Name, value, isMutable: true);
                     }
                     else
                     {
@@ -184,9 +225,10 @@ namespace Descrio.Execution
                 }
 
                 var interpreter = new Interpreter(localContext);
-                foreach (var stmt in statement.Statements)
+                foreach (var stmt in statements)
                 {
                     var result = await interpreter.ExecuteAsync(stmt);
+
                     if (result.Flow == FlowState.Return)
                     {
                         return result.Value;
@@ -196,12 +238,10 @@ namespace Descrio.Execution
                         throw new InvalidOperationException($"'{result.Flow}' is not valid outside of a loop.");
                     }
                 }
-                return null; // Implicit return null
+                return null;
             }
 
-            var callable = new DelegateCallable(CallAsync);
-            _context.Callables.Register(statement.Name, callable);
-            return new ValueTask<VisitResult>(VisitResult.Normal);
+            return new DelegateCallable(CallAsync);
         }
 
         private async ValueTask<VisitResult> ExecuteAsync(WhenStatement statement)

--- a/Packages/com.nueruyu.descrio/Runtime/Expressions/LambdaExpression.cs
+++ b/Packages/com.nueruyu.descrio/Runtime/Expressions/LambdaExpression.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+
+namespace Descrio
+{
+    /// <summary>
+    /// Represents a lambda expression, an anonymous function that can capture its surrounding scope.
+    /// </summary>
+    public class LambdaExpression : IExpression
+    {
+        public ParameterDefinition[] Parameters { get; }
+        public IStatement[] Statements { get; }
+
+        public LambdaExpression(ParameterDefinition[] parameters, IStatement[] statements)
+        {
+            Parameters = parameters ?? System.Array.Empty<ParameterDefinition>();
+            Statements = statements ?? System.Array.Empty<IStatement>();
+        }
+    }
+}

--- a/Packages/com.nueruyu.descrio/Runtime/Expressions/LambdaExpression.cs.meta
+++ b/Packages/com.nueruyu.descrio/Runtime/Expressions/LambdaExpression.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 570c1d6105df17e4db55c8511ce2d2c9

--- a/Packages/com.nueruyu.descrio/Runtime/Yaml/Nodes/LambdaNode.cs
+++ b/Packages/com.nueruyu.descrio/Runtime/Yaml/Nodes/LambdaNode.cs
@@ -1,29 +1,25 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using YamlDotNet.Serialization;
 
 namespace Descrio.Yaml.Nodes
 {
-    internal class FunctionNode : IStatementNode
+    internal class LambdaNode : IExpressionNode
     {
-        [YamlMember(Alias = "name")]
-        public string Name { get; set; }
-
         [YamlMember(Alias = "parameters")]
         public ParameterDefinitionNode[] Parameters { get; set; } = Array.Empty<ParameterDefinitionNode>();
 
         [YamlMember(Alias = "statements")]
         public IStatementNode[] Statements { get; set; } = Array.Empty<IStatementNode>();
 
-        public IStatement ToStatement()
+        public IExpression ToExpression()
         {
             var instructions = Statements.Select(s => s.ToStatement()).ToArray();
             var parameters = Parameters.Select(p => new ParameterDefinition(
                 p.Name,
                 p.Type,
                 p.DefaultValue)).ToArray();
-            return new FunctionStatement(Name, parameters, instructions);
+            return new LambdaExpression(parameters, instructions);
         }
     }
 }

--- a/Packages/com.nueruyu.descrio/Runtime/Yaml/Nodes/LambdaNode.cs.meta
+++ b/Packages/com.nueruyu.descrio/Runtime/Yaml/Nodes/LambdaNode.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ee9ffbb49ed5494478079bff052cf785

--- a/Packages/com.nueruyu.descrio/Runtime/Yaml/Nodes/ParameterDefinitionNode.cs
+++ b/Packages/com.nueruyu.descrio/Runtime/Yaml/Nodes/ParameterDefinitionNode.cs
@@ -1,0 +1,16 @@
+using YamlDotNet.Serialization;
+
+namespace Descrio.Yaml.Nodes
+{
+    internal class ParameterDefinitionNode
+    {
+        [YamlMember(Alias = "name")]
+        public string Name { get; set; }
+
+        [YamlMember(Alias = "type")]
+        public string Type { get; set; }
+
+        [YamlMember(Alias = "default")]
+        public object DefaultValue { get; set; }
+    }
+}

--- a/Packages/com.nueruyu.descrio/Runtime/Yaml/Nodes/ParameterDefinitionNode.cs.meta
+++ b/Packages/com.nueruyu.descrio/Runtime/Yaml/Nodes/ParameterDefinitionNode.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1e67319e9e0a6954888e8ee0f43d4198

--- a/Packages/com.nueruyu.descrio/Runtime/Yaml/YamlScriptParser.cs
+++ b/Packages/com.nueruyu.descrio/Runtime/Yaml/YamlScriptParser.cs
@@ -22,6 +22,7 @@ namespace Descrio.Yaml
                 .WithTagMapping("!run", typeof(RunNode))
                 .WithTagMapping("!dispatch", typeof(DispatchNode))
                 .WithTagMapping("!function", typeof(FunctionNode))
+                .WithTagMapping("!lambda", typeof(LambdaNode))
                 .WithTagMapping("!when", typeof(WhenNode))
                 .WithTagMapping("!for", typeof(ForNode))
                 .WithTagMapping("!while", typeof(WhileNode))

--- a/Packages/com.nueruyu.descrio/Tests/Editor/StatementExecutionTests/LambdaExpressionTests.cs
+++ b/Packages/com.nueruyu.descrio/Tests/Editor/StatementExecutionTests/LambdaExpressionTests.cs
@@ -1,0 +1,111 @@
+using NUnit.Framework;
+using System; // For Convert
+using System.Threading.Tasks;
+using static Descrio.EditorTests.TestStatementFactory;
+using static Descrio.EditorTests.TestExpressionFactory;
+
+namespace Descrio.EditorTests.StatementExecutionTests
+{
+    [TestFixture]
+    public class LambdaExpressionTests : StatementTestBase
+    {
+        private async Task ExecuteStatements(params IStatement[] statements)
+        {
+            foreach (var statement in statements)
+            {
+                await Env.ExecuteAsync(statement);
+            }
+        }
+
+        [Test]
+        public async Task Lambda_CanBeAssignedToVariableAndExecuted()
+        {
+            // Arrange
+            var lambda = new LambdaExpression(
+                new[] { new ParameterDefinition("x", null, null) },
+                new[] { Return(Binary(Variable("x"), OperatorType.Multiply, Literal(2))) }
+            );
+
+            // Act
+            await ExecuteStatements(
+                Let("double_op", lambda),
+                Let("result", Run("double_op", ("x", Literal(5))).Build())
+            );
+
+            // Assert
+            var result = Env.VariableRegistry.Get("result");
+            Assert.AreEqual(10m, Convert.ToDecimal(result));
+        }
+
+        [Test]
+        public async Task Lambda_AsArgument_CanBeUsedAsCallback()
+        {
+            // Arrange
+            var applyFunc = Function("Apply")
+                .WithParams("value", "operation")
+                .Body(Return(Run("operation", ("val", Variable("value"))).Build()));
+
+            var lambda = new LambdaExpression(
+                new[] { new ParameterDefinition("val", null, null) },
+                new[] { Return(Binary(Variable("val"), OperatorType.Add, Literal(10))) }
+            );
+
+            // Act
+            await ExecuteStatements(
+                applyFunc.Build(),
+                Let("result", Run("Apply", ("value", Literal(5)), ("operation", lambda)).Build())
+            );
+
+            // Assert
+            var result = Env.VariableRegistry.Get("result");
+            Assert.AreEqual(15m, Convert.ToDecimal(result));
+        }
+
+        [Test]
+        public async Task Closure_LambdaCapturesOuterScopeVariable()
+        {
+            // Arrange
+            var createAdderFunc = Function("CreateAdder")
+                .WithParams("amount")
+                .Body(
+                    Return(new LambdaExpression(
+                        new[] { new ParameterDefinition("x", null, null) },
+                        new[] { Return(Binary(Variable("x"), OperatorType.Add, Variable("amount"))) }
+                    ))
+                );
+
+            // Act
+            await ExecuteStatements(
+                createAdderFunc.Build(),
+                Let("add5", Run("CreateAdder", ("amount", Literal(5))).Build()),
+                Let("result", Run("add5", ("x", Literal(10))).Build())
+            );
+
+            // Assert
+            var result = Env.VariableRegistry.Get("result");
+            Assert.AreEqual(15m, Convert.ToDecimal(result));
+        }
+
+        [Test]
+        public async Task Closure_LambdaSeesUpdatedValue_OfCapturedVariable()
+        {
+            // Arrange
+            var lambda = new LambdaExpression(
+                new[] { new ParameterDefinition("x", null, null) },
+                new[] { Return(Binary(Variable("x"), OperatorType.Multiply, Variable("multiplier"))) }
+            );
+
+            // Act
+            await ExecuteStatements(
+                Var("multiplier", Literal(2)),
+                Let("my_lambda", lambda),
+                Assign(Variable("multiplier"), Literal(10)),
+                Let("result", Run("my_lambda", ("x", Literal(5))).Build())
+            );
+
+            // Assert
+            var result = Env.VariableRegistry.Get("result");
+            Assert.AreEqual(50m, Convert.ToDecimal(result));
+        }
+    }
+}

--- a/Packages/com.nueruyu.descrio/Tests/Editor/StatementExecutionTests/LambdaExpressionTests.cs.meta
+++ b/Packages/com.nueruyu.descrio/Tests/Editor/StatementExecutionTests/LambdaExpressionTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2aba8bae4f3a649439131568f3ce4441

--- a/Packages/com.nueruyu.descrio/Tests/Editor/StatementParserTests.cs
+++ b/Packages/com.nueruyu.descrio/Tests/Editor/StatementParserTests.cs
@@ -129,6 +129,31 @@ statements:
         }
 
         [Test]
+        public void ParseExpression_Lambda_ShouldParseCorrectly()
+        {
+            var yaml = @"!lambda
+parameters:
+  - name: p1
+    type: string
+    default: 'default'
+statements:
+  - !run
+    name: log
+    args:
+      val: !expr p1";
+            var expression = _parser.ParseExpression(yaml);
+
+            Assert.IsInstanceOf<LambdaExpression>(expression);
+            var lambda = (LambdaExpression)expression;
+            Assert.AreEqual(1, lambda.Parameters.Length);
+            Assert.AreEqual("p1", lambda.Parameters[0].Name);
+            Assert.AreEqual("string", lambda.Parameters[0].Type);
+            Assert.AreEqual("default", lambda.Parameters[0].DefaultValue);
+            Assert.AreEqual(1, lambda.Statements.Length);
+            Assert.IsInstanceOf<RunStatement>(lambda.Statements[0]);
+        }
+
+        [Test]
         public void ParseStatement_TryCatch_ShouldParseCorrectly()
         {
             var yaml = @"!try


### PR DESCRIPTION
Closes #11

This PR introduces support for anonymous functions (lambdas) and closures via a new `!lambda` tag, significantly enhancing the expressiveness of the Descrio scripting language. This change enables higher-order functions, allowing callables to be treated as first-class citizens that can be assigned to variables, passed as arguments, and returned from other functions.

### Motivation

As outlined in the feature request, the language becomes far more powerful with the ability to define functions on-the-fly. This is essential for implementing callback patterns, functional programming styles, and creating more modular and reusable script logic.

### Implementation Details

The implementation follows the proposed design, with key refinements to ensure code quality and consistency with the existing architecture.

**1. New `!lambda` Syntax**

A `!lambda` expression can be used anywhere a value is expected. It evaluates to a callable object that can be stored in a variable or passed directly as an argument.

```yaml
# Example: Using a lambda as a callback
!let
  name: my_list
  value: [10, 20, 30]

!let
  name: add_amount
  value: 5

# The lambda captures 'add_amount' from its surrounding scope
!let
  name: add_op
  value: !lambda
    parameters: [val]
    statements:
      - !return { value: !expr 'val + add_amount' }

# 'ApplyToList' would be a function that accepts a list and a callable
!run
  name: ApplyToList
  args:
    list: !expr my_list
    operation: !expr add_op
```

**2. Centralized Callable Creation**

The core execution logic for both named functions (`!function`) and lambdas (`!lambda`) has been consolidated into a single private `CreateCallable` method within the `Interpreter`.
- This helper method accepts parameter definitions, a statement body, and the definition-time `ExecutionContext`.
- It returns a `DelegateCallable` that correctly captures the lexical scope, forming a closure.
- This refactoring eliminates code duplication and ensures consistent behavior between named and anonymous functions.

**3. Unified Function Call Mechanism**

The `!run` statement's behavior has been extended to fully support first-class functions:
- It first attempts to resolve a callable by name from the `CallableRegistry`.
- If not found, it performs a **fallback lookup** for a **variable** of the same name.
- If the variable's value is an `ICallable`, it is invoked. This allows for the intuitive `!run { name: my_lambda_variable }` syntax.

**4. AST and Parser Updates**

- A `LambdaExpression` class has been added to the AST.
- A corresponding `LambdaNode` and `!lambda` tag mapping have been added to the `YamlScriptParser`.
- `ParameterDefinitionNode` was refactored into a shared component to be used by both `FunctionNode` and `LambdaNode`.

**5. Comprehensive Testing**

A new test suite, `LambdaExpressionTests.cs`, has been added to validate the new functionality, including:
- Creating and executing simple lambdas.
- Using lambdas as callbacks.
- Verifying that closures correctly capture variables from their outer scope.
- Ensuring that captured variables reflect updates made after the lambda's definition.