### PR TITLE
feat(execution): enforce case-sensitive identifier resolution

### DIFF
--- a/Packages/com.nueruyu.descrio/Runtime/Execution/CallableRegistry.cs
+++ b/Packages/com.nueruyu.descrio/Runtime/Execution/CallableRegistry.cs
@@ -6,7 +6,7 @@ namespace Descrio.Execution
 {
     public class CallableRegistry
     {
-        private readonly Dictionary<string, ICallable> _callables = new(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, ICallable> _callables = new(StringComparer.Ordinal);
         private readonly CallableRegistry _parent;
 
         public CallableRegistry(CallableRegistry parent = null)

--- a/Packages/com.nueruyu.descrio/Runtime/Execution/ClassRegistry.cs
+++ b/Packages/com.nueruyu.descrio/Runtime/Execution/ClassRegistry.cs
@@ -5,7 +5,7 @@ namespace Descrio.Execution
 {
     public class ClassRegistry
     {
-        private readonly Dictionary<string, Type> _classes = new(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, Type> _classes = new(StringComparer.Ordinal);
         private readonly ClassRegistry _parent;
 
         public ClassRegistry(ClassRegistry parent = null)

--- a/Packages/com.nueruyu.descrio/Runtime/Execution/VariableRegistry.cs
+++ b/Packages/com.nueruyu.descrio/Runtime/Execution/VariableRegistry.cs
@@ -17,7 +17,7 @@ namespace Descrio.Execution
             }
         }
 
-        private readonly Dictionary<string, Variable> _variables = new(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, Variable> _variables = new(StringComparer.Ordinal);
         private readonly VariableRegistry _parent;
 
         public VariableRegistry(VariableRegistry parent = null)

--- a/Packages/com.nueruyu.descrio/Tests/Editor/StatementExecutionTests/FunctionStatementTests.cs
+++ b/Packages/com.nueruyu.descrio/Tests/Editor/StatementExecutionTests/FunctionStatementTests.cs
@@ -41,5 +41,23 @@ namespace Descrio.EditorTests.StatementExecutionTests
             Assert.IsNull(result.Value);
             CollectionAssert.AreEqual(new[] { "done" }, Env.LogHistory);
         }
+
+        [Test]
+        public void Function_CallIsCaseSensitive_ShouldThrow()
+        {
+            // Arrange
+            var definition = Function("myFunc").Body(Return(Literal(true)));
+
+            // Act
+            var ex = Assert.ThrowsAsync<System.InvalidOperationException>(async () =>
+            {
+                await Env.ExecuteAsync(definition);
+                // This should fail because 'myfunc' is not 'myFunc'
+                await Env.ExecuteAsync(Run("myfunc"));
+            });
+
+            // Assert
+            StringAssert.Contains("Callable 'myfunc' not found", ex.Message);
+        }
     }
 }

--- a/Packages/com.nueruyu.descrio/Tests/Editor/StatementExecutionTests/ThrowStatementTests.cs
+++ b/Packages/com.nueruyu.descrio/Tests/Editor/StatementExecutionTests/ThrowStatementTests.cs
@@ -78,5 +78,17 @@ namespace Descrio.EditorTests.StatementExecutionTests
             var ex = Assert.ThrowsAsync<InvalidOperationException>(async () => await Env.ExecuteAsync(throwStatement));
             StringAssert.Contains("'NotAnError' is not a valid and registered exception class", ex.Message);
         }
+
+        [Test]
+        public void Throw_RegisteredClassNameIsCaseSensitive_ShouldThrow()
+        {
+            // Arrange
+            Env.RegisterClass("MyError", typeof(InvalidOperationException));
+            var throwStatement = Throw("myerror"); // Using incorrect case
+
+            // Act & Assert
+            var ex = Assert.ThrowsAsync<InvalidOperationException>(async () => await Env.ExecuteAsync(throwStatement));
+            StringAssert.Contains("'myerror' is not a valid and registered exception class", ex.Message);
+        }
     }
 }

--- a/Packages/com.nueruyu.descrio/Tests/Editor/StatementExecutionTests/VarStatementTests.cs
+++ b/Packages/com.nueruyu.descrio/Tests/Editor/StatementExecutionTests/VarStatementTests.cs
@@ -23,5 +23,21 @@ namespace Descrio.EditorTests.StatementExecutionTests
             // Assert
             Assert.AreEqual(20, result.Value);
         }
+
+        [Test]
+        public void Var_AccessIsCaseSensitive_ShouldThrow()
+        {
+            // Arrange
+            var varStatement = Var("myVar", Literal(100));
+
+            // Act & Assert
+            var ex = Assert.ThrowsAsync<System.InvalidOperationException>(async () =>
+            {
+                await Env.ExecuteAsync(varStatement);
+                // This should fail because 'myvar' is not 'myVar'
+                await Env.ExecuteAsync(Variable("myvar"));
+            });
+            StringAssert.Contains("Variable 'myvar' is not defined", ex.Message);
+        }
     }
 }


### PR DESCRIPTION
fix #42

## Overview

This pull request enforces strict case-sensitivity for all identifier resolutions, including variables, functions (callables), and class names. It changes the previous case-insensitive behavior to align with standard scripting language practices, making the interpreter more predictable and robust.

## Changes Made

The `Dictionary` string comparer in the following files has been changed from `StringComparer.OrdinalIgnoreCase` to `StringComparer.Ordinal`:

-   `Runtime/Execution/VariableRegistry.cs`
-   `Runtime/Execution/CallableRegistry.cs`
-   `Runtime/Execution/ClassRegistry.cs`

## Tests Added

Unit tests have been added to confirm that resolution is now case-sensitive for:

-   **Variables**: Ensures that a variable defined as `myVar` cannot be accessed as `myvar`.
-   **Functions**: Ensures that a function defined as `myFunc` cannot be called as `myfunc`.
-   **Class Names**: Ensures that a registered class `MyError` cannot be referenced as `myerror` in a `!throw` statement.

## Rationale

The previous case-insensitive approach could lead to subtle bugs where identifiers like `myVar` and `myvar` were treated as identical. This change eliminates that ambiguity and improves the overall reliability of the scripting engine.```