### PR TITLE
fix(execution): Isolate module scopes to prevent definition leaks

### DIFF
--- a/Packages/com.nueruyu.descrio/Runtime/Execution/CallableRegistry.cs
+++ b/Packages/com.nueruyu.descrio/Runtime/Execution/CallableRegistry.cs
@@ -32,5 +32,10 @@ namespace Descrio.Execution
             callable = null;
             return false;
         }
+
+        public IReadOnlyDictionary<string, ICallable> GetDefinedCallables()
+        {
+            return new Dictionary<string, ICallable>(_callables, _callables.Comparer);
+        }
     }
 }

--- a/Packages/com.nueruyu.descrio/Runtime/Execution/ClassRegistry.cs
+++ b/Packages/com.nueruyu.descrio/Runtime/Execution/ClassRegistry.cs
@@ -33,5 +33,10 @@ namespace Descrio.Execution
             type = null;
             return false;
         }
+
+        public IReadOnlyDictionary<string, Type> GetDefinedClasses()
+        {
+            return new Dictionary<string, Type>(_classes, _classes.Comparer);
+        }
     }
 }

--- a/Packages/com.nueruyu.descrio/Runtime/ScriptRunner.cs
+++ b/Packages/com.nueruyu.descrio/Runtime/ScriptRunner.cs
@@ -3,7 +3,6 @@ using Descrio.Parse;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using ExecutionContext = Descrio.Execution.ExecutionContext;
@@ -12,6 +11,18 @@ namespace Descrio
 {
     public class ScriptRunner
     {
+        private class ModuleExecutionResult
+        {
+            public CallableRegistry Callables { get; }
+            public ClassRegistry Classes { get; }
+
+            public ModuleExecutionResult(CallableRegistry callables, ClassRegistry classes)
+            {
+                Callables = callables;
+                Classes = classes;
+            }
+        }
+
         private readonly IModuleLoader _moduleLoader;
         private readonly Dictionary<string, ICallable> _callables = new();
         private readonly Dictionary<string, Type> _types = new();
@@ -56,7 +67,7 @@ namespace Descrio
             string currentWorkingDirectory,
             CancellationToken cancellationToken = default)
         {
-            var loadedModules = new ModuleRegistry();
+            var executedModules = new Dictionary<ModulePath, ModuleExecutionResult>();
             var cwdPath = new ModulePath(currentWorkingDirectory);
 
             var globalCallables = new CallableRegistry();
@@ -85,56 +96,64 @@ namespace Descrio
             globalClasses.Register("ArgumentError", typeof(ArgumentException));
             globalClasses.Register("FileNotFoundError", typeof(FileNotFoundException));
 
-            var entrypointModulePath = cwdPath.Resolve(entrypointPath);
             var globalContext = new ExecutionContext(
-                entrypointModulePath.GetDirectoryPath(),
+                cwdPath,
                 globalCallables,
                 globalVariables,
                 globalClasses,
                 cancellationToken);
 
-            await LoadModuleAndDependenciesAsync(entrypointModulePath, globalContext, loadedModules);
+            var entrypointModulePath = cwdPath.Resolve(entrypointPath);
+            await LoadAndExecuteModuleAsync(entrypointModulePath, globalContext, executedModules);
         }
 
-        private async Task<Module> LoadModuleAndDependenciesAsync(
+        private async Task<ModuleExecutionResult> LoadAndExecuteModuleAsync(
             ModulePath path,
             ExecutionContext globalContext,
-            ModuleRegistry loadedModules)
+            Dictionary<ModulePath, ModuleExecutionResult> executedModules)
         {
             globalContext.CancellationToken.ThrowIfCancellationRequested();
 
-            if (loadedModules.TryGetModule(path, out var existingModule))
+            if (executedModules.TryGetValue(path, out var existingResult))
             {
-                return existingModule;
+                return existingResult;
             }
 
             var module = await _moduleLoader.LoadAsync(path, globalContext.CancellationToken);
 
-            loadedModules.RegisterModule(path, module);
+            var moduleCallableRegistry = new CallableRegistry(globalContext.Callables);
+            var moduleClassRegistry = new ClassRegistry(globalContext.Classes);
+            var moduleVariableRegistry = new VariableRegistry(globalContext.Variables);
 
-            // Create a context for the current module. It needs the correct directory path
-            // to resolve its own dependencies.
             var moduleExecutionContext = new ExecutionContext(
                 path.GetDirectoryPath(),
-                globalContext.Callables,
-                new VariableRegistry(globalContext.Variables), // Create a new, isolated variable registry for this module.
-                globalContext.Classes,
+                moduleCallableRegistry,
+                moduleVariableRegistry,
+                moduleClassRegistry,
                 globalContext.CancellationToken);
 
-            // When loading dependencies, we resolve their paths relative to the CURRENT module,
-            // but we pass the GLOBAL context down to the recursive call. This ensures
-            // that all modules are peers under the global scope, rather than being nested.
             foreach (var importPath in module.ImportPaths)
             {
                 var absoluteImportPath = moduleExecutionContext.CurrentDirectory.Resolve(importPath);
-                await LoadModuleAndDependenciesAsync(absoluteImportPath, globalContext, loadedModules);
+                var dependencyResult = await LoadAndExecuteModuleAsync(absoluteImportPath, globalContext, executedModules);
+
+                foreach (var (name, callable) in dependencyResult.Callables.GetDefinedCallables())
+                {
+                    moduleCallableRegistry.Register(name, callable);
+                }
+
+                foreach (var (name, type) in dependencyResult.Classes.GetDefinedClasses())
+                {
+                    moduleClassRegistry.Register(name, type);
+                }
             }
 
-            // Execute this module's statements using its own isolated context.
             var interpreter = new Interpreter(moduleExecutionContext);
             await interpreter.ExecuteAsync(module);
 
-            return module;
+            var result = new ModuleExecutionResult(moduleCallableRegistry, moduleClassRegistry);
+            executedModules[path] = result;
+            return result;
         }
     }
 }

--- a/Packages/com.nueruyu.descrio/Tests/Editor/ScriptRunnerTests.cs
+++ b/Packages/com.nueruyu.descrio/Tests/Editor/ScriptRunnerTests.cs
@@ -152,5 +152,38 @@ namespace Descrio.EditorTests
             // Assert
             CollectionAssert.AreEqual(new object[] { "value_from_b" }, _logHistory);
         }
+
+        [Test]
+        public void ExecuteAsync_SiblingModuleFunctions_AreNotAccessible()
+        {
+            var modules = new Dictionary<string, Module>
+            {
+                { "/moduleA.yaml", new Module(
+                    statements: new IStatement[]
+                    {
+                        Function("func_A").Body(Return(Literal("from A"))).Build()
+                    },
+                    importPaths: Array.Empty<string>())
+                },
+                { "/moduleB.yaml", new Module(
+                    statements: new IStatement[]
+                    {
+                        Run("func_A").Build()
+                    },
+                    importPaths: Array.Empty<string>())
+                },
+                { "/main.yaml", new Module(
+                    statements: Array.Empty<IStatement>(),
+                    importPaths: new[] { "moduleA.yaml", "moduleB.yaml" })
+                }
+            };
+            var loader = new InMemoryModuleLoader(modules);
+            var runner = new ScriptRunner(loader);
+
+            var ex = Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await runner.ExecuteAsync("/main.yaml", "/")
+            );
+            StringAssert.Contains("Callable 'func_A' not found", ex.Message);
+        }
     }
 }


### PR DESCRIPTION
fix #43

## Description

This pull request resolves a critical issue where sibling modules could access each other's function and class definitions, which breaks module encapsulation and could lead to unintended name collisions.

The root cause was that all modules effectively shared a single, global scope for callables and classes. This commit refactors the module loading architecture in `ScriptRunner` to enforce proper scoping rules. Now, a module only has visibility into:

1.  Globally registered (built-in) definitions.
2.  Definitions from the modules it **explicitly** imports.

## Changes

-   **Refactored `ScriptRunner.cs`**: The module loading logic has been re-architected. It now recursively loads dependencies and merges their exported definitions into the importing module's scope. This ensures that definitions do not leak between sibling modules.
-   **Enhanced Registries**: Added `GetDefinedCallables()` to `CallableRegistry.cs` and `GetDefinedClasses()` to `ClassRegistry.cs`. These methods are essential for the new loading mechanism to identify and export only the definitions made within a specific module.
-   **Added Integration Test**: A new test case has been added to `ScriptRunnerTests.cs` that specifically verifies that a function defined in `moduleA.yaml` is not accessible from its sibling, `moduleB.yaml`, when both are imported by `main.yaml`.

## Impact

This change significantly improves the robustness and predictability of the module system, making it safer to compose complex logic from multiple script files without worrying about unintended side effects.