### PR TITLE
feat(expressions): Allow expressions as dictionary keys

### DIFF
--- a/Packages/com.nueruyu.descrio/Runtime/Execution/Interpreter.cs
+++ b/Packages/com.nueruyu.descrio/Runtime/Execution/Interpreter.cs
@@ -457,15 +457,21 @@ namespace Descrio.Execution
 
         private async ValueTask<VisitResult> ExecuteAsync(DictionaryExpression expression)
         {
-            var results = new Dictionary<string, object>(StringComparer.Ordinal);
-            foreach (var (key, valueExpr) in expression.Entries)
+            var results = new Dictionary<object, object>();
+            foreach (var (keyExpr, valueExpr) in expression.Entries)
             {
+                var keyResult = await ExecuteAsync(keyExpr);
+                if (keyResult.Flow != FlowState.Normal)
+                {
+                    return keyResult;
+                }
+
                 var valueResult = await ExecuteAsync(valueExpr);
                 if (valueResult.Flow != FlowState.Normal)
                 {
                     return valueResult;
                 }
-                results[key] = valueResult.Value;
+                results[keyResult.Value] = valueResult.Value;
             }
             return VisitResult.NormalWithValue(results);
         }

--- a/Packages/com.nueruyu.descrio/Runtime/Expressions/DictionaryExpression.cs
+++ b/Packages/com.nueruyu.descrio/Runtime/Expressions/DictionaryExpression.cs
@@ -1,16 +1,14 @@
 using System.Collections.Generic;
-using System.Threading.Tasks;
-using Descrio.Execution;
 
 namespace Descrio
 {
     public class DictionaryExpression : IExpression
     {
-        public IReadOnlyDictionary<string, IExpression> Entries { get; }
+        public IReadOnlyDictionary<IExpression, IExpression> Entries { get; }
 
-        public DictionaryExpression(IReadOnlyDictionary<string, IExpression> entries)
+        public DictionaryExpression(IReadOnlyDictionary<IExpression, IExpression> entries)
         {
-            Entries = entries ?? new Dictionary<string, IExpression>();
+            Entries = entries ?? new Dictionary<IExpression, IExpression>();
         }
     }
 }

--- a/Packages/com.nueruyu.descrio/Runtime/Yaml/Nodes/DictionaryExpressionNode.cs
+++ b/Packages/com.nueruyu.descrio/Runtime/Yaml/Nodes/DictionaryExpressionNode.cs
@@ -5,9 +5,9 @@ namespace Descrio.Yaml.Nodes
 {
     internal class DictionaryExpressionNode : IExpressionNode
     {
-        public Dictionary<string, IExpressionNode> Entries { get; set; }
+        public Dictionary<IExpressionNode, IExpressionNode> Entries { get; set; }
 
-        public DictionaryExpressionNode(Dictionary<string, IExpressionNode> entries)
+        public DictionaryExpressionNode(Dictionary<IExpressionNode, IExpressionNode> entries)
         {
             Entries = entries;
         }
@@ -15,7 +15,7 @@ namespace Descrio.Yaml.Nodes
         public IExpression ToExpression()
         {
             var expressions = Entries.ToDictionary(
-                kvp => kvp.Key,
+                kvp => kvp.Key.ToExpression(),
                 kvp => kvp.Value.ToExpression());
             return new DictionaryExpression(expressions);
         }

--- a/Packages/com.nueruyu.descrio/Runtime/Yaml/Serialization/ExpressionNodeDeserializer.cs
+++ b/Packages/com.nueruyu.descrio/Runtime/Yaml/Serialization/ExpressionNodeDeserializer.cs
@@ -1,7 +1,5 @@
 using System;
 using Descrio.Parse;
-using Descrio.Parse.Expressions;
-using YamlDotNet.Core.Events;
 using YamlDotNet.Core;
 using YamlDotNet.Serialization;
 using Descrio.Yaml.Nodes;
@@ -42,7 +40,7 @@ namespace Descrio.Yaml.Serialization
 
                 case Dictionary<object, object> dict:
                     return new DictionaryExpressionNode(dict.ToDictionary(
-                        kvp => kvp.Key.ToString(),
+                        kvp => ConvertItem(kvp.Key),
                         kvp => ConvertItem(kvp.Value)
                     ));
 

--- a/Packages/com.nueruyu.descrio/Tests/Editor/Builders/DictionaryExpressionBuilder.cs
+++ b/Packages/com.nueruyu.descrio/Tests/Editor/Builders/DictionaryExpressionBuilder.cs
@@ -4,21 +4,21 @@ namespace Descrio.EditorTests.Builders
 {
     public class DictionaryExpressionBuilder : IExpressionBuilder
     {
-        private readonly Dictionary<string, IExpression> _elements = new();
+        private readonly Dictionary<IExpression, IExpression> _elements = new();
 
         internal DictionaryExpressionBuilder()
         {
         }
 
-        public DictionaryExpressionBuilder With(string key, IExpression value)
+        public DictionaryExpressionBuilder With(IExpression key, IExpression value)
         {
             _elements.Add(key, value);
             return this;
         }
 
-        public DictionaryExpressionBuilder With(string key, object value)
+        public DictionaryExpressionBuilder With(object key, object value)
         {
-            _elements.Add(key, new LiteralExpression(value));
+            _elements.Add(new LiteralExpression(key), new LiteralExpression(value));
             return this;
         }
 

--- a/Packages/com.nueruyu.descrio/Tests/Editor/StatementExecutionTests/DictionaryExpressionTests.cs
+++ b/Packages/com.nueruyu.descrio/Tests/Editor/StatementExecutionTests/DictionaryExpressionTests.cs
@@ -1,0 +1,55 @@
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using static Descrio.EditorTests.TestStatementFactory;
+using static Descrio.EditorTests.TestExpressionFactory;
+
+namespace Descrio.EditorTests.StatementExecutionTests
+{
+    [TestFixture]
+    public class DictionaryExpressionTests : StatementTestBase
+    {
+        [Test]
+        public async Task Dictionary_WithExpressionAsKey_ShouldEvaluateCorrectly()
+        {
+            // Arrange
+            await Env.ExecuteAsync(Let("my_key", Literal("dynamic_key")));
+            var dictExpr = Dictionary()
+                .With(Variable("my_key"), Literal(123))
+                .With(Literal("static_key"), Literal(456))
+                .Build();
+
+            // Act
+            var result = await Env.ExecuteAsync(dictExpr);
+            var dict = result.Value as Dictionary<object, object>;
+
+            // Assert
+            Assert.IsNotNull(dict);
+            Assert.AreEqual(2, dict.Count);
+            Assert.IsTrue(dict.ContainsKey("dynamic_key"));
+            Assert.AreEqual(123L, dict["dynamic_key"]);
+            Assert.IsTrue(dict.ContainsKey("static_key"));
+            Assert.AreEqual(456L, dict["static_key"]);
+        }
+
+        [Test]
+        public async Task Dictionary_WithComplexExpressionAsKey_ShouldEvaluateCorrectly()
+        {
+            // Arrange
+            await Env.ExecuteAsync(Let("key_part", Literal("user_")));
+            var dictExpr = Dictionary()
+                .With(InterpolatedString(Variable("key_part"), Literal("id")), Literal(99))
+                .Build();
+
+            // Act
+            var result = await Env.ExecuteAsync(dictExpr);
+            var dict = result.Value as Dictionary<object, object>;
+
+            // Assert
+            Assert.IsNotNull(dict);
+            Assert.AreEqual(1, dict.Count);
+            Assert.IsTrue(dict.ContainsKey("user_id"));
+            Assert.AreEqual(99L, dict["user_id"]);
+        }
+    }
+}

--- a/Packages/com.nueruyu.descrio/Tests/Editor/StatementExecutionTests/DictionaryExpressionTests.cs.meta
+++ b/Packages/com.nueruyu.descrio/Tests/Editor/StatementExecutionTests/DictionaryExpressionTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7dacde9f95cf4e94192283b5d6e359cb

--- a/Packages/com.nueruyu.descrio/Tests/Editor/StatementParserTests.cs
+++ b/Packages/com.nueruyu.descrio/Tests/Editor/StatementParserTests.cs
@@ -261,15 +261,15 @@ default:
             var dict = (DictionaryExpression)expression;
             Assert.AreEqual(3, dict.Entries.Count);
 
-            var entry1 = dict.Entries.First(kvp => ((LiteralExpression)kvp.Key).Value.Equals("key1"));
+            var entry1 = dict.Entries.Single(kvp => kvp.Key is LiteralExpression l && l.Value.Equals("key1"));
             Assert.IsInstanceOf<LiteralExpression>(entry1.Value);
             Assert.AreEqual("value1", ((LiteralExpression)entry1.Value).Value);
 
-            var entry2 = dict.Entries.First(kvp => ((LiteralExpression)kvp.Key).Value.Equals(123L));
+            var entry2 = dict.Entries.Single(kvp => kvp.Key is LiteralExpression l && l.Value.Equals(123L));
             Assert.IsInstanceOf<LiteralExpression>(entry2.Value);
             Assert.AreEqual(456L, ((LiteralExpression)entry2.Value).Value);
 
-            var entry3 = dict.Entries.First(kvp => kvp.Key is VariableExpression);
+            var entry3 = dict.Entries.Single(kvp => kvp.Key is VariableExpression);
             Assert.AreEqual("my_var", ((VariableExpression)entry3.Key).VariableName);
             Assert.IsInstanceOf<VariableExpression>(entry3.Value);
             Assert.AreEqual("my_val", ((VariableExpression)entry3.Value).VariableName);

--- a/Packages/com.nueruyu.descrio/Tests/Editor/StatementParserTests.cs
+++ b/Packages/com.nueruyu.descrio/Tests/Editor/StatementParserTests.cs
@@ -252,17 +252,27 @@ default:
         {
             var yaml = @"{
   key1: 'value1',
-  key2: 123,
-  key3: !expr my_var
+  123: 456,
+  !expr my_var: !expr my_val
 }";
             var expression = _parser.ParseExpression(yaml);
 
             Assert.IsInstanceOf<DictionaryExpression>(expression);
             var dict = (DictionaryExpression)expression;
             Assert.AreEqual(3, dict.Entries.Count);
-            Assert.IsInstanceOf<LiteralExpression>(dict.Entries["key1"]);
-            Assert.IsInstanceOf<LiteralExpression>(dict.Entries["key2"]);
-            Assert.IsInstanceOf<VariableExpression>(dict.Entries["key3"]);
+
+            var entry1 = dict.Entries.First(kvp => ((LiteralExpression)kvp.Key).Value.Equals("key1"));
+            Assert.IsInstanceOf<LiteralExpression>(entry1.Value);
+            Assert.AreEqual("value1", ((LiteralExpression)entry1.Value).Value);
+
+            var entry2 = dict.Entries.First(kvp => ((LiteralExpression)kvp.Key).Value.Equals(123L));
+            Assert.IsInstanceOf<LiteralExpression>(entry2.Value);
+            Assert.AreEqual(456L, ((LiteralExpression)entry2.Value).Value);
+
+            var entry3 = dict.Entries.First(kvp => kvp.Key is VariableExpression);
+            Assert.AreEqual("my_var", ((VariableExpression)entry3.Key).VariableName);
+            Assert.IsInstanceOf<VariableExpression>(entry3.Value);
+            Assert.AreEqual("my_val", ((VariableExpression)entry3.Value).VariableName);
         }
 
         [Test]


### PR DESCRIPTION
## Overview

This pull request addresses issue #33 by enabling the use of expressions (such as variables) as dictionary keys, in addition to string literals. This allows for the construction of more dynamic and flexible data structures within scripts.

## Changes

-   **Updated `DictionaryExpression` & `DictionaryExpressionNode`:**
    -   The key type has been changed from `string` to `IExpression` (and `IExpressionNode` respectively).
    -   Files changed: `Runtime/Expressions/DictionaryExpression.cs`, `Runtime/Yaml/Nodes/DictionaryExpressionNode.cs`

-   **Updated `ExpressionNodeDeserializer`:**
    -   Modified the deserializer to recursively convert dictionary keys into `IExpressionNode` objects when parsing YAML.
    -   File changed: `Runtime/Yaml/Serialization/ExpressionNodeDeserializer.cs`

-   **Updated `Interpreter`:**
    -   Adjusted the logic for evaluating a `DictionaryExpression` to execute both the key and value expressions before creating the runtime `Dictionary<object, object>`.
    -   File changed: `Runtime/Execution/Interpreter.cs`

-   **Added and updated tests:**
    -   Updated `DictionaryExpressionBuilder` to support `IExpression` keys.
    -   Added a new test file (`DictionaryExpressionTests.cs`) to verify cases where expressions are used as keys.
    -   Updated the existing parser tests (`StatementParserTests.cs`).

## Related Issues

-   Closes #33